### PR TITLE
Heroku Deployment bug fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ app.use((err, req, res, next) => {
   res.render('error');
 });
 
-if (process.env.NODE_ENV === 'production') {
+/*if (process.env.NODE_ENV === 'production') {
   const credentials = {
     cert: fs.readFileSync('/etc/cert/cert.pem', 'utf8'),
     key: fs.readFileSync('/etc/cert/key.pem', 'utf8'),
@@ -68,6 +68,9 @@ if (process.env.NODE_ENV === 'production') {
 const httpServer = http.createServer(app);
 httpServer.listen(80, () => {
   console.log('HTTPS Server running on port 443');
-});
+});*/
+
+app.listen(process.env.PORT || 3000, 
+	() => console.log("Server is running..."));
 
 module.exports = app;

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -35,9 +35,9 @@ const {
 } = require('../helpers/utils');
 
 router.get('/', (req, res, next) => {
-  if (req.get('host') !== 'cbtracker.cwsdev.net' && process.env.NODE_ENV === 'production') {
+  /*if (req.get('host') !== 'cbtracker.cwsdev.net' && process.env.NODE_ENV === 'production') {
     return res.redirect('https://cbtracker.cwsdev.net');
-  }
+  }*/
   return res.render('index', { title: 'CryptoBlades Tracker' });
 });
 


### PR DESCRIPTION
When deploying to your own heroku server, an error will be thrown in app.js:

`Error: ENOENT: no such file or directory, open '/etc/cert/cert.pem'`

This was presumably due to developer having his own SSL certificate in the project. This was commented away and used `app.listen()` instead.

In addition, server was redirecting to developer's own server instead. I have commented that away and the app should now work in your own heroku server.