### PR TITLE
Make the import function compatible with Linux-style line breaks

### DIFF
--- a/public/build/js/core.js
+++ b/public/build/js/core.js
@@ -548,11 +548,13 @@ function import_data() {
                 hideAddress = (hideAddress === 'true')
                 currCurrency = currency
             } else {
-                var rows = fr.result.split("\r\n")
+                var rows = fr.result.split("\n")
                 console.log(rows)
                 if (rows.length) {
                     rows.forEach(row => {
                         var [name,address] = row.split(',')
+                        name = name.trim()
+                        address = address.trim()
                         if (name && address) {
                             if (isAddress(address) && !storeAccounts.includes(address)) {
                                 storeAccounts.push(address)


### PR DESCRIPTION
• The import function only works for Windows-style line breaks ("\r\n") and isn't working for Linux / Mac-style line breaks ("\n"). This PR fixes that so it works for both

Reference: https://stackoverflow.com/questions/10059142/reading-r-carriage-return-vs-n-newline-from-console-with-getc/10059171#:~:text=%5Cn%20is%20the%20newline%20character,the%20enter%20key%20was%20pressed.

• Added input value trimming so lines like "name, address" (notice the whitespace) in the input file will be correctly processed