### PR TITLE
Update app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ app.use((err, req, res, next) => {
 
 const httpServer = http.createServer(app);
 const httpPort = config.port || 3000;
-httpServer.listen(httpPort, 'localhost', () => {
+httpServer.listen(httpPort, '0.0.0.0', () => {
   console.log(`HTTP Server running on port ${httpPort}`);
 });
 


### PR DESCRIPTION
Changes webserver designation from localhost to 0.0.0.0 for Docker compatibility. Prior, docker containers mapping port 3000 could not be connected to from remote machines. 

Verified works for both remote docker hosts, and also still from a locally hosted machine, docker or not.